### PR TITLE
Boost classes in search

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,6 +65,9 @@
             "typedoc-plugin-rename-defaults"
         ],
         "readme": "INDEX.md",
+        "searchGroupBoosts": {
+            "Classes": 2
+        },
         "sortEntryPoints": false,
 
         // Options for typedoc-plugin-extras


### PR DESCRIPTION
Changes this:

![image](https://github.com/playcanvas/api-reference/assets/697563/2c3db47b-4b00-4b9a-9a2d-d6e3d7c0b284)

To this:

![image](https://github.com/playcanvas/api-reference/assets/697563/f95e8117-c3f8-48da-b3bb-6574aa30ad46)

Fixes #5 