### PR TITLE
Hides nav on smaller screens. Fixes #10

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,11 @@
+@media (max-width: 769px) {
+    #tsd-toolbar-links {
+        display: none;
+    }
+}
+
+@media (min-width: 770px) {
+    #tsd-toolbar-links {
+        display: flex;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,6 +66,7 @@
         ],
         "readme": "INDEX.md",
         "sortEntryPoints": false,
+        "customCss": "styles.css",
 
         // Options for typedoc-plugin-extras
         "customDescription": "Combined API reference manual for PlayCanvas",


### PR DESCRIPTION
Adds a custom css tag and hides the nav on mobile at the same breakpoints used in other elements.

<img width="456" alt="image" src="https://github.com/playcanvas/api-reference/assets/430764/6456eb60-336b-46f6-8875-a02f444df05b">
