### PR TITLE
Add React API 

### DIFF
--- a/index.html
+++ b/index.html
@@ -620,9 +620,15 @@
             border-radius: 4px;
             transition: background-color 0.2s;
             margin-right: 8px;
-            width: 145px;
+            min-width: 145px;
             text-align: center;
             margin-bottom: 8px;
+        }
+
+        .module-link.external::after {
+            content: ' ↗';
+            padding-left: 8px;
+            vertical-align: middle;
         }
 
         .module-link.legacy {
@@ -785,6 +791,11 @@
                                 <p>The core PlayCanvas engine featuring rendering, physics, animation, sound, and more.</p>
                                 <a href="./engine/" class="module-link">v2.x API (current)</a>
                                 <a href="./engine-v1/" class="module-link legacy">v1.x API (legacy)</a>
+                            </li>
+                            <li class="module-item" data-name="react">
+                                <h3>📖 React</h3>
+                                <p>Use React’s declarative power to build PlayCanvas apps with components, hooks, and JSX.</p>
+                                <a href="https://playcanvas-react.vercel.app/docs/api" class="module-link external">View API Reference</a>
                             </li>
                             <li class="module-item" data-name="web-components">
                                 <h3>📖 Web Components</h3>

--- a/index.html
+++ b/index.html
@@ -792,6 +792,11 @@
                                 <a href="./engine/" class="module-link">v2.x API (current)</a>
                                 <a href="./engine-v1/" class="module-link legacy">v1.x API (legacy)</a>
                             </li>
+                            <li class="module-item" data-name="editor">
+                                <h3>📖 Editor</h3>
+                                <p>API for interfacing with the PlayCanvas Editor.</p>
+                                <a href="./editor/" class="module-link">View API Reference</a>
+                            </li>
                             <li class="module-item" data-name="react">
                                 <h3>📖 React</h3>
                                 <p>Use React’s declarative power to build PlayCanvas apps with components, hooks, and JSX.</p>
@@ -802,16 +807,6 @@
                                 <p>Custom HTML elements for building declarative PlayCanvas applications.</p>
                                 <a href="./web-components/" class="module-link">View API Reference</a>
                             </li>
-                            <li class="module-item" data-name="editor">
-                                <h3>📖 Editor</h3>
-                                <p>API for interfacing with the PlayCanvas Editor.</p>
-                                <a href="./editor/" class="module-link">View API Reference</a>
-                            </li>
-                            <li class="module-item" data-name="observer">
-                                <h3>📖 Observer</h3>
-                                <p>Reactive data observation and binding system.</p>
-                                <a href="./observer/" class="module-link">View API Reference</a>
-                            </li>
                             <li class="module-item" data-name="pcui">
                                 <h3>📖 PCUI</h3>
                                 <p>User interface component library for creating tools and editors.</p>
@@ -821,6 +816,11 @@
                                 <h3>📖 PCUI Graph</h3>
                                 <p>Graph user interface components for creating node-based editors.</p>
                                 <a href="./pcui-graph/" class="module-link">View API Reference</a>
+                            </li>
+                            <li class="module-item" data-name="observer">
+                                <h3>📖 Observer</h3>
+                                <p>Reactive data observation and binding system.</p>
+                                <a href="./observer/" class="module-link">View API Reference</a>
                             </li>
                         </ul>
                     </section>


### PR DESCRIPTION
Adds a link to the @playcanvas/react API docs — just to fill the gap while we consider adding inline docs.

<img width="464" alt="image" src="https://github.com/user-attachments/assets/24129001-1959-4052-aaa8-8d0b4df57807" />

