### PR TITLE
Add unified cross-product search to the landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,33 @@ This cross-platform script will:
 3. Install dependencies for each repository
 4. Build the TypeDoc documentation for each repository
 5. Copy the documentation to a central `docs` folder
-6. Create a main index.html file that allows navigation between the different API references
-7. Generate a combined sitemap.xml that includes URLs from all repositories for better SEO
+6. Merge the per-product TypeDoc search indexes into a combined `docs/assets/search.js` that powers the landing page's global search
+7. Create a main index.html file that allows navigation between the different API references
+8. Generate a combined sitemap.xml that includes URLs from all repositories for better SEO
+
+### Global Search
+
+The landing page provides a search across all products. It reuses TypeDoc's own
+search client (`main.js`, copied from the engine build) pointed at a combined
+index that `build.mjs` produces by decoding each product's
+`docs/<product>/assets/search.js` (`window.searchData` = base64, deflate-compressed
+JSON), prefixing row URLs with the product folder, tagging rows with a
+`product-<folder>` class (styled as a badge by `assets/landing.css`), and
+rebuilding a single lunr index in the same format.
+
+Per-repository search behavior is configured in `repos-config.json`:
+
+- `searchExclude`: omit the product from the combined index (used for the legacy `engine-v1`)
+- `searchBoost`: relevance multiplier for all of the product's results
+- `searchKindBoosts`: per-reflection-kind multipliers (e.g. `{ "128": 2 }` boosts classes, mirroring the engine's TypeDoc `searchGroupBoosts`)
+
+> [!IMPORTANT]
+> The merge step depends on TypeDoc 0.28 internals: the `window.searchData`
+> wrapper, deflate encoding, and a serialized lunr **2.3.9** index (the `lunr`
+> devDependency in `package.json` is pinned to match the version bundled in
+> TypeDoc's client). The build validates each product's index and skips it with
+> a warning if the format changes — revisit `mergeSearchIndexes()` in `build.mjs`
+> when upgrading TypeDoc.
 
 > [!NOTE]  
 > The build script automatically cleans and recreates the `repos` directory each time it's run, ensuring you always get a fresh build with the latest code from the configured branches.

--- a/assets/landing.css
+++ b/assets/landing.css
@@ -87,6 +87,29 @@
     content: " ↗";
 }
 
+/* Product badges on combined search results. The build's merged search index
+   tags each row with a product-<folder> class; TypeDoc's search client copies
+   row classes onto the result <li> verbatim. */
+#tsd-search-results li[class*="product-"] .text::after {
+    margin-left: 0.5rem;
+    padding: 0.1rem 0.4rem;
+    border: 1px solid var(--color-accent);
+    border-radius: 0.25rem;
+    background-color: var(--color-background-secondary);
+    color: var(--color-text-aside);
+    font-size: 0.75rem;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
+#tsd-search-results li.product-engine .text::after          { content: "Engine"; }
+#tsd-search-results li.product-editor .text::after          { content: "Editor"; }
+#tsd-search-results li.product-pcui .text::after            { content: "PCUI"; }
+#tsd-search-results li.product-pcui-graph .text::after      { content: "PCUI Graph"; }
+#tsd-search-results li.product-observer .text::after        { content: "Observer"; }
+#tsd-search-results li.product-web-components .text::after  { content: "Web Components"; }
+#tsd-search-results li.product-splat-transform .text::after { content: "Splat Transform"; }
+
 .landing-nav-category {
     margin: 1rem 0 0.25rem;
     color: var(--color-text-aside);

--- a/build.mjs
+++ b/build.mjs
@@ -4,6 +4,13 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { promisify } from 'util';
+import zlib from 'zlib';
+
+import lunr from 'lunr';
+
+const deflate = promisify(zlib.deflate);
+const inflate = promisify(zlib.inflate);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -161,7 +168,11 @@ function copySharedAssets() {
   ensureDir(path.join('docs', 'assets'));
   fs.copyFileSync(stylePath, path.join('docs', 'assets', 'style.css'));
   fs.copyFileSync(path.join(engineAssets, 'icons.svg'), path.join('docs', 'assets', 'icons.svg'));
-  console.log('Copied shared TypeDoc assets (style.css, icons.svg)');
+  // main.js drives the landing page's search dialog, theme select and mobile
+  // menu; icons.js injects the SVG sprite that search result icons reference
+  fs.copyFileSync(path.join(engineAssets, 'main.js'), path.join('docs', 'assets', 'main.js'));
+  fs.copyFileSync(path.join(engineAssets, 'icons.js'), path.join('docs', 'assets', 'icons.js'));
+  console.log('Copied shared TypeDoc assets (style.css, icons.svg, main.js, icons.js)');
 }
 
 /**
@@ -240,6 +251,79 @@ function postProcessProductDocs() {
 
     console.log(`Post-processed ${count} pages in ${targetFolderName}`);
   }
+}
+
+/**
+ * Merge the per-product TypeDoc search indexes into a single combined index at
+ * docs/assets/search.js so the landing page can search across all products.
+ *
+ * TypeDoc 0.28 writes each product's index as `window.searchData = "<base64>"`
+ * where the payload is deflate-compressed JSON of the form { rows, index }:
+ * rows hold display data ({ kind, name, url, classes, icon?, parent? }) and
+ * index is a serialized lunr 2.3.9 index over the row names. The combined file
+ * uses the exact same format, so TypeDoc's stock client (assets/main.js) can
+ * consume it unchanged. Each merged row gets its URL prefixed with the product
+ * folder and a `product-<folder>` class that landing.css styles as a badge.
+ */
+async function mergeSearchIndexes() {
+  const rows = [];
+  // Mirror TypeDoc's builder settings exactly (JavascriptIndexPlugin) so the
+  // shipped client accepts the rebuilt index: trimmer-only pipeline, ref "id",
+  // and the same field weights.
+  const builder = new lunr.Builder();
+  builder.pipeline.add(lunr.trimmer);
+  builder.ref('id');
+  builder.field('name', { boost: 10 });
+  builder.field('comment', { boost: 1 });
+  builder.field('document', { boost: 1 });
+
+  let merged = 0;
+  for (const repo of REPOS) {
+    if (repo.searchExclude) {
+      continue;
+    }
+    const targetFolderName = repo.name === 'editor-api' ? 'editor' : repo.name;
+    const searchPath = path.join('docs', targetFolderName, 'assets', 'search.js');
+    if (!fs.existsSync(searchPath)) {
+      console.warn(`Warning: No search index found for ${repo.name} at ${searchPath}`);
+      continue;
+    }
+
+    try {
+      const match = fs.readFileSync(searchPath, 'utf8').match(/^window\.searchData = "(.*)";/s);
+      if (!match) {
+        throw new Error('unexpected search.js wrapper');
+      }
+      const data = JSON.parse((await inflate(Buffer.from(match[1], 'base64'))).toString());
+      if (!Array.isArray(data.rows) || !data.index?.version?.startsWith('2.3')) {
+        throw new Error(`unexpected searchData shape (lunr ${data.index?.version}) - TypeDoc format may have changed`);
+      }
+
+      for (const row of data.rows) {
+        const boost = (repo.searchBoost ?? 1) * (repo.searchKindBoosts?.[row.kind] ?? 1);
+        builder.add({ name: row.name, id: rows.length }, { boost });
+        rows.push({
+          ...row,
+          url: `${targetFolderName}/${row.url}`,
+          classes: `${row.classes || ''} product-${targetFolderName}`.trim()
+        });
+      }
+      merged++;
+    } catch (error) {
+      console.warn(`Warning: Could not merge search index for ${repo.name}: ${error.message}`);
+    }
+  }
+
+  if (merged === 0) {
+    console.warn('Warning: No product search indexes found; skipping combined search index');
+    return;
+  }
+
+  const json = JSON.stringify({ rows, index: builder.build() });
+  const payload = (await deflate(Buffer.from(json))).toString('base64');
+  ensureDir(path.join('docs', 'assets'));
+  fs.writeFileSync(path.join('docs', 'assets', 'search.js'), `window.searchData = "${payload}";`);
+  console.log(`Combined search index: ${rows.length} rows from ${merged} products (${Math.round(payload.length / 1024)} KB)`);
 }
 
 /**
@@ -567,6 +651,10 @@ async function buildDocs() {
     // Make the route back to the landing page obvious on every product page
     console.log('\nPost-processing product docs...');
     postProcessProductDocs();
+
+    // Merge the per-product search indexes for the landing page's global search
+    console.log('\nMerging product search indexes...');
+    await mergeSearchIndexes();
 
     // Copy TypeDoc's stylesheet and icons for the landing page to share
     console.log('\nCopying shared TypeDoc assets...');

--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
     <link rel="icon" href="favicon.ico">
     <link rel="stylesheet" href="assets/style.css">
     <link rel="stylesheet" href="assets/landing.css">
+    <script defer src="assets/main.js"></script>
+    <script async src="assets/icons.js" id="tsd-icons-script"></script>
+    <script async src="assets/search.js" id="tsd-search-script"></script>
 </head>
 <body>
     <script>(() => {
@@ -26,6 +29,12 @@
                 <a href="https://forum.playcanvas.com/">Forum</a>
                 <a href="https://github.com/playcanvas">GitHub</a>
             </div>
+            <button id="tsd-search-trigger" class="tsd-widget" aria-label="Search"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><use href="assets/icons.svg#icon-search"></use></svg></button>
+            <dialog id="tsd-search" aria-label="Search">
+                <input role="combobox" id="tsd-search-input" aria-controls="tsd-search-results" aria-autocomplete="list" aria-expanded="true" autocapitalize="off" autocomplete="off" placeholder="Search the docs" maxLength="100"/>
+                <ul role="listbox" id="tsd-search-results"></ul>
+                <div id="tsd-search-status" aria-live="polite" aria-atomic="true"><div>Preparing search index...</div></div>
+            </dialog>
             <a href="#" class="tsd-widget menu" id="tsd-toolbar-menu-trigger" data-toggle="menu" aria-label="Menu" aria-expanded="false"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><use href="assets/icons.svg#icon-menu"></use></svg></a>
         </div>
     </header>
@@ -155,25 +164,5 @@
         <p class="tsd-generator">Generated using <a href="https://typedoc.org/" target="_blank" rel="noopener noreferrer">TypeDoc</a> on {{BUILD_DATE}}</p>
     </footer>
     <div class="overlay"></div>
-    <script>
-        const themeSelect = document.getElementById("tsd-theme");
-        // dataset.theme was validated against os/light/dark on load
-        themeSelect.value = document.documentElement.dataset.theme;
-        themeSelect.addEventListener("change", () => {
-            localStorage.setItem("tsd-theme", themeSelect.value);
-            document.documentElement.dataset.theme = themeSelect.value;
-        });
-
-        const menuTrigger = document.getElementById("tsd-toolbar-menu-trigger");
-        menuTrigger.addEventListener("click", (e) => {
-            e.preventDefault();
-            const open = document.documentElement.classList.toggle("has-menu");
-            menuTrigger.setAttribute("aria-expanded", String(open));
-        });
-        document.querySelector(".overlay").addEventListener("click", () => {
-            document.documentElement.classList.remove("has-menu");
-            menuTrigger.setAttribute("aria-expanded", "false");
-        });
-    </script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "lunr": "2.3.9",
         "serve": "14.2.6"
       }
     },
@@ -557,6 +558,13 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "url": "https://github.com/playcanvas/api-reference.git"
   },
   "devDependencies": {
+    "lunr": "2.3.9",
     "serve": "14.2.6"
   },
   "scripts": {

--- a/repos-config.json
+++ b/repos-config.json
@@ -3,12 +3,15 @@
     {
       "name": "engine",
       "url": "https://github.com/playcanvas/engine.git",
-      "branch": "release-2.20"
+      "branch": "release-2.20",
+      "searchBoost": 1.25,
+      "searchKindBoosts": { "128": 2 }
     },
     {
       "name": "engine-v1",
       "url": "https://github.com/playcanvas/engine.git",
-      "branch": "release-1.77"
+      "branch": "release-1.77",
+      "searchExclude": true
     },
     {
       "name": "pcui",


### PR DESCRIPTION
## What

Adds a global search to the landing page that spans all products, so visitors no longer need to know which product a symbol lives in before they can search for it.

- **`build.mjs`**: new `mergeSearchIndexes()` step (runs in both full and `--landing-only` builds) decodes each product''s TypeDoc search index (`window.searchData` = base64, deflate-compressed JSON containing a serialized lunr 2.3.9 index), prefixes row URLs with the product folder, tags each row with a `product-<folder>` class, rebuilds a single combined index with TypeDoc-identical builder settings, and writes it to `docs/assets/search.js`. `copySharedAssets()` now also copies TypeDoc''s `main.js` and `icons.js` from the engine build.
- **`index.html`**: adds TypeDoc 0.28''s stock search trigger/dialog markup and script tags. The hand-rolled inline theme/menu handlers are removed since `main.js` now drives those elements (same markup contract the landing page already mirrors).
- **`assets/landing.css`**: styles the `product-<folder>` class as a badge (Engine, PCUI, ...) on each search result, themed via TypeDoc CSS variables.
- **`repos-config.json`**: new optional per-repo search fields — engine gets `searchBoost: 1.25` and `searchKindBoosts: {128: 2}` (restores its TypeDoc `searchGroupBoosts` class boost, which is baked into the original index and lost on re-merge); `engine-v1` is excluded via `searchExclude` to keep ~4,700 near-duplicate legacy symbols out (its own per-product search is untouched).
- **`package.json`**: adds `lunr@2.3.9`, pinned to match the version bundled in TypeDoc''s client.

## Why reuse TypeDoc''s client instead of writing a custom search UI

The landing page already mirrors TypeDoc''s markup and reuses its stylesheet. Pointing TypeDoc''s own `main.js` at a combined index in the exact same format gets the dialog UX, ranking, Ctrl+K / `/` shortcuts, keyboard navigation, a11y, and graceful failure with zero client-side JS to maintain.

## Notes for reviewers

- The combined index is 9,575 rows from 7 products, ~347 KB base64 — comparable to the engine''s own 206 KB per-product index, and loaded `async` the same way.
- The merge validates each product''s index (wrapper format + lunr version) and skips it with a build warning instead of failing, so TypeDoc format drift in one upstream repo degrades that product''s coverage rather than breaking the site. The coupling (searchData wrapper, deflate, lunr 2.3.9) is documented in the README.
- Verified locally against the full built `docs/` tree: round-trip decode/query in Node, plus browser checks (search/keyboard shortcuts/theme toggle/mobile menu, light+dark themes, result navigation to `/engine/classes/AppBase.html`, missing-index failure modes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)